### PR TITLE
Give nicer error messages on test failure

### DIFF
--- a/uzsttp/src/test/scala/uzsttp/servers/WebsocketTest.scala
+++ b/uzsttp/src/test/scala/uzsttp/servers/WebsocketTest.scala
@@ -132,8 +132,10 @@ object WebsocketTest extends DefaultRunnableSpec {
     emptyStream,
     nonEmptyStream,
     cutShortInfiniteStream,
-  ).provideCustomLayerShared(AsyncHttpClientZioBackend.layer() ++ Clock.live ++ serverLayer2M(endPoints)).mapError(TestFailure.fail)
-
+  ).provideCustomLayerShared(AsyncHttpClientZioBackend.layer() ++ Clock.live ++ serverLayer2M(endPoints)).mapError {
+    case a: TestFailure.Assertion => a
+    case o => TestFailure.fail(o)
+  }
   override def spec = streamTests
 
 }


### PR DESCRIPTION
Wrapping assertions failures in another layer of `TestFailure.fail` makes their output rather uninformative.
By returning `TestFailure.Assertion`s as they are, everything is as it should be.